### PR TITLE
Informative error is now thrown in mapPut

### DIFF
--- a/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/HandlerException.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/HandlerException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Payara Services Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.jsftemplating.handlers;
+
+/**
+ * This exception is thrown if there is an error when processing a
+ * {@link com.sun.jsftemplating.layout.descriptors.handler.Handler}
+ * @author jonathan coustick
+ */
+public class HandlerException extends RuntimeException {
+    
+    public HandlerException(String message) {
+        super(message);
+    }
+    
+}

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/UtilHandlers.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/UtilHandlers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -303,6 +304,9 @@ public class UtilHandlers {
 	)
     public static void mapPut(HandlerContext context) {
 	Map map = (Map) context.getInputValue("map");
+        if (map == null) {
+            throw new HandlerException(context.getHandler().getInputValue("map") + " resolved to null");
+        }
 	Object key = context.getInputValue("key");
 	Object value = context.getInputValue("value");
 	map.put(key, value);

--- a/jsftemplating/src/test/java/com/sun/jsftemplating/handlers/UtilHandlerTest.java
+++ b/jsftemplating/src/test/java/com/sun/jsftemplating/handlers/UtilHandlerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 Payara Services Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContextImpl;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.IODescriptor;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author jonathan coustick
+ */
+public class UtilHandlerTest {
+    
+    @Test
+    public void mapPutNullTest() {
+        HandlerContext context = new HandlerContextImpl(null, null, null, null);
+        HandlerDefinition mapPutDefinition = new HandlerDefinition("mapPut");
+        mapPutDefinition.setHandlerMethod(UtilHandlers.class.getCanonicalName(), "mapPut");
+        IODescriptor mapDescriptor = new IODescriptor("map", Map.class.getCanonicalName());
+        Map<String, IODescriptor> inputsMap = new HashMap<String, IODescriptor>();
+        inputsMap.put("map", mapDescriptor);
+        mapPutDefinition.setInputDefs(inputsMap);
+        
+        Handler mapPutHandler = new Handler(mapPutDefinition);
+        mapPutHandler.setInputValue("map", null);
+        
+        context.setHandler(mapPutHandler);
+        try {
+            UtilHandlers.mapPut(context);
+            Assert.fail("mapPut failed to throw exception");
+        } catch(HandlerException ex) {
+            //expected result
+        }
+    }
+    
+    
+    
+}


### PR DESCRIPTION
If the map given as an input resolves to null in the given context
an exception is now thrown saying what the error is and the String
that was given as an input.