### PR TITLE
Fix form value hidden by a value in page context

### DIFF
--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
@@ -97,7 +97,13 @@ public class PageSessionResolver extends ELResolver {
 
     @Override
     public void setValue(ELContext elContext, Object base, Object property, Object value) {
-        checkPropertyFound(base, property);
+        if (base != null) {
+            return;
+        }
+
+        if (property == null) {
+            throw new PropertyNotFoundException();
+        }
 
         FacesContext facesContext = (FacesContext) elContext.getContext(FacesContext.class);
         UIViewRoot viewRoot = facesContext.getViewRoot();

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
@@ -98,6 +98,13 @@ public class PageSessionResolver extends ELResolver {
     @Override
     public void setValue(ELContext elContext, Object base, Object property, Object value) {
         checkPropertyFound(base, property);
+
+        FacesContext facesContext = (FacesContext) elContext.getContext(FacesContext.class);
+        UIViewRoot viewRoot = facesContext.getViewRoot();
+        Map pageSession = getPageSession(facesContext, viewRoot);
+        if (pageSession != null) {
+            pageSession.put(property.toString(), value);
+        }
     }
 
     @Override


### PR DESCRIPTION
Sometimes Page context resolver goes before the general EL resolver.  If it contains the same property (e.g. from the model before update) then it hides the value in other sources (e.g. in the post data from a form). 

This fix sets the value from the form also to page context so that it's not covered by an older value. Fixes a bug in GlassFish Admin Console for some form values: https://github.com/eclipse-ee4j/glassfish/issues/24434