### PR TITLE
Improve page session attributes resolution

### DIFF
--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
@@ -29,38 +29,29 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * <p>
- * This <code>ELResolver</code> exists to resolve "page session" attributes. This concept, borrowed from
- * NetDynamics / JATO, stores data w/ the page so that it is available throughout the life of the page. This is longer
- * than request scope, but usually shorter than session.
- * </p>
+ * This {@link ELResolver} exists to resolve "page session" attributes. This concept, borrowed from
+ * NetDynamics / JATO, stores data w/ the page so that it is available throughout the life of the page.
+ * This is longer than request scope, but usually shorter than session.
  *
  * <p>
  * This implementation stores the attributes on the {@link UIViewRoot}.
- * </p>
  *
  * @author Ken Paulsen (ken.paulsen@sun.com)
  */
 public class PageSessionResolver extends ELResolver {
 
     /**
-     * <p>
      * The name an expression must use when it explicitly specifies page session ("pageSession").
-     * </p>
      */
     public static final String PAGE_SESSION = "pageSession";
 
     /**
-     * <p>
      * The attribute key in which to store the "page" session Map.
-     * </p>
      */
     private static final String PAGE_SESSION_KEY = "_ps";
 
     /**
-     * <p>
      * Checks standard scopes and "page session" to see if the value exists.
-     * </p>
      */
     @Override
     public Object getValue(ELContext elContext, Object base, Object property) {
@@ -151,11 +142,9 @@ public class PageSessionResolver extends ELResolver {
     }
 
     /**
-     * <p>
-     * This method provides access to the "page session" <code>Map</code>. If it doesn't exist, it returns
-     * <code>null</code>. If the given <code>UIViewRoot</code> is null, then the current <code>UIViewRoot</code>
+     * This method provides access to the "page session" {@link Map}. If it doesn't exist, it returns
+     * {@code null}. If the given {@link UIViewRoot} is {@code null}, then the current {@link UIViewRoot}
      * will be used.
-     * </p>
      */
     @SuppressWarnings("unchecked")
     public static Map<String, Serializable> getPageSession(FacesContext facesContext, UIViewRoot viewRoot) {
@@ -166,10 +155,8 @@ public class PageSessionResolver extends ELResolver {
     }
 
     /**
-     * <p>
-     * This method will create a new "page session" <code>Map</code> if it doesn't exist yet.
-     * It will overwrite any existing "page session" <code>Map</code>, so be careful.
-     * </p>
+     * This method will create a new "page session" {@code Map} if it doesn't exist yet.
+     * It will overwrite any existing "page session" {@code Map}, so be careful.
      */
     public static Map<String, Serializable> createPageSession(FacesContext facesContext, UIViewRoot viewRoot) {
         if (viewRoot == null) {

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutViewHandler.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutViewHandler.java
@@ -247,21 +247,8 @@ public class LayoutViewHandler extends ViewHandler {
         }
 
         // Restore the current UIViewRoot.
-        // Because new UIViewRoot was temporary set, this will clear
-        // view map, which also contains our "page session".
-        // Thus we need reset a new view root's view map after restore original
-        // view root.
-        if (currentViewRoot != null) {            
-            Map<String, Object> pageSession = viewRoot.getViewMap(false);            
-            if (pageSession != null) {
-                pageSession = new HashMap<>(pageSession);
-            }
-            
+        if (currentViewRoot != null) {
             context.setViewRoot(currentViewRoot);
-            
-            if (pageSession != null) {
-                viewRoot.getViewMap().putAll(pageSession);
-            }
         }
 
         // Return the populated UIViewRoot

--- a/jsftemplating/src/main/resources/META-INF/faces-config.xml
+++ b/jsftemplating/src/main/resources/META-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-	Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -19,83 +19,80 @@
 -->
 
 <faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
-        version="4.0">
-
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+              version="4.0">
 
     <!--
         Templating for JavaServer Faces Technology default JavaServer Faces
-	configuration file.
+        configuration file.
     -->
 
     <application>
-        <!-- -->
-	<view-handler>com.sun.jsftemplating.layout.LayoutViewHandler</view-handler>
-	<state-manager>com.sun.jsftemplating.layout.LayoutStateManager</state-manager>
-	<el-resolver>com.sun.jsftemplating.el.PageSessionResolver</el-resolver>
-        <!-- -->
+        <view-handler>com.sun.jsftemplating.layout.LayoutViewHandler</view-handler>
+        <state-manager>com.sun.jsftemplating.layout.LayoutStateManager</state-manager>
+        <el-resolver>com.sun.jsftemplating.el.PageSessionResolver</el-resolver>
         <locale-config>
-          <default-locale>en</default-locale>
+            <default-locale>en</default-locale>
         </locale-config>
     </application>
 
     <component>
-	<component-type>com.sun.jsftemplating.EventComponent</component-type>
-	<component-class>com.sun.jsftemplating.component.EventComponent</component-class>
+        <component-type>com.sun.jsftemplating.EventComponent</component-type>
+        <component-class>com.sun.jsftemplating.component.EventComponent</component-class>
     </component>
     <component>
-	<component-type>com.sun.jsftemplating.If</component-type>
-	<component-class>com.sun.jsftemplating.component.If</component-class>
+        <component-type>com.sun.jsftemplating.If</component-type>
+        <component-class>com.sun.jsftemplating.component.If</component-class>
     </component>
     <component>
-	<component-type>com.sun.jsftemplating.While</component-type>
-	<component-class>com.sun.jsftemplating.component.While</component-class>
+        <component-type>com.sun.jsftemplating.While</component-type>
+        <component-class>com.sun.jsftemplating.component.While</component-class>
     </component>
     <component>
-	<component-type>com.sun.jsftemplating.ForEach</component-type>
-	<component-class>com.sun.jsftemplating.component.ForEach</component-class>
+        <component-type>com.sun.jsftemplating.ForEach</component-type>
+        <component-class>com.sun.jsftemplating.component.ForEach</component-class>
     </component>
     <component>
-	<component-type>com.sun.jsftemplating.AjaxRequest</component-type>
-	<component-class>com.sun.jsftemplating.component.AjaxRequest</component-class>
+        <component-type>com.sun.jsftemplating.AjaxRequest</component-type>
+        <component-class>com.sun.jsftemplating.component.AjaxRequest</component-class>
     </component>
     <component>
-	<component-type>com.sun.jsftemplating.StaticText</component-type>
-	<component-class>com.sun.jsftemplating.component.StaticText</component-class>
+        <component-type>com.sun.jsftemplating.StaticText</component-type>
+        <component-class>com.sun.jsftemplating.component.StaticText</component-class>
     </component>
 
     <render-kit>
-	<renderer>
-	    <component-family>com.sun.jsftemplating.EventComponent</component-family>
-	    <renderer-type>com.sun.jsftemplating.EventComponent</renderer-type>
-	    <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
-	</renderer>
-	<renderer>
-	    <component-family>com.sun.jsftemplating.If</component-family>
-	    <renderer-type>com.sun.jsftemplating.If</renderer-type>
-	    <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
-	</renderer>
-	<renderer>
-	    <component-family>com.sun.jsftemplating.While</component-family>
-	    <renderer-type>com.sun.jsftemplating.While</renderer-type>
-	    <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
-	</renderer>
-	<renderer>
-	    <component-family>com.sun.jsftemplating.ForEach</component-family>
-	    <renderer-type>com.sun.jsftemplating.ForEach</renderer-type>
-	    <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
-	</renderer>
-	<renderer>
-	    <component-family>com.sun.jsftemplating.AjaxRequest</component-family>
-	    <renderer-type>com.sun.jsftemplating.AjaxRequest</renderer-type>
-	    <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
-	</renderer>
-	<renderer>
-	    <component-family>com.sun.jsftemplating.StaticText</component-family>
-	    <renderer-type>com.sun.jsftemplating.StaticText</renderer-type>
-	    <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
-	</renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.EventComponent</component-family>
+            <renderer-type>com.sun.jsftemplating.EventComponent</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.If</component-family>
+            <renderer-type>com.sun.jsftemplating.If</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.While</component-family>
+            <renderer-type>com.sun.jsftemplating.While</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.ForEach</component-family>
+            <renderer-type>com.sun.jsftemplating.ForEach</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.AjaxRequest</component-family>
+            <renderer-type>com.sun.jsftemplating.AjaxRequest</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.StaticText</component-family>
+            <renderer-type>com.sun.jsftemplating.StaticText</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
     </render-kit>
 
 </faces-config>

--- a/jsftemplating/src/main/resources/META-INF/faces-config.xml
+++ b/jsftemplating/src/main/resources/META-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-	Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+	Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the


### PR DESCRIPTION
This PR based on very detailed [@OndroMih](https://github.com/eclipse-ee4j/glassfish/issues/24383#issuecomment-1517784322)'s comment.

What happens:

* If `pageSession` explicitly requested, return it
* Else if `pageSession` not found or doesn't contains `property`, return `null`
* Else if `property` present in `pageSession`, check standard scopes (request, view, session and application) for an updated value
* Else return value from our custom page session.

This generally emulates behavior as for Jakarta Server Faces 3.0 VariableResolver Chain Wrapper.

I reverted from store page session to view map, because view map cleared on an every call of the `FacesContext.setViewRoot()` and we cannot control each call of this method.