### PR TITLE
Restrict access to the vulnerable EL expressions

### DIFF
--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/MethodNotAllowedException.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/MethodNotAllowedException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import jakarta.el.ELException;
+
+/**
+ * Thrown when a method could not be accessed while evaluating a
+ * {@link jakarta.el.MethodExpression MethodExpression}.
+ *
+ * @author avpinchuk
+ */
+public class MethodNotAllowedException extends ELException {
+
+    private static final long serialVersionUID = -1L;
+
+    /**
+     * Creates a {@link MethodNotAllowedException} with no detail message.
+     */
+    public MethodNotAllowedException() {
+        super();
+    }
+
+    /**
+     * Creates a {@link MethodNotAllowedException} with the given detail message.
+     *
+     * @param message the detail message
+     */
+    public MethodNotAllowedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a {@link MethodNotAllowedException} with the given root cause.
+     *
+     * @param cause the originating cause of this exception
+     */
+    public MethodNotAllowedException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a {@link MethodNotAllowedException} with the given detail message
+     * and root cause.
+     *
+     * @param message the detail message
+     * @param cause the originating cause of this exception
+     */
+    public MethodNotAllowedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/MethodNotAllowedException.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/MethodNotAllowedException.java
@@ -24,43 +24,7 @@ import jakarta.el.ELException;
  *
  * @author avpinchuk
  */
-public class MethodNotAllowedException extends ELException {
+final class MethodNotAllowedException extends ELException {
 
-    private static final long serialVersionUID = -1L;
-
-    /**
-     * Creates a {@link MethodNotAllowedException} with no detail message.
-     */
-    public MethodNotAllowedException() {
-        super();
-    }
-
-    /**
-     * Creates a {@link MethodNotAllowedException} with the given detail message.
-     *
-     * @param message the detail message
-     */
-    public MethodNotAllowedException(String message) {
-        super(message);
-    }
-
-    /**
-     * Creates a {@link MethodNotAllowedException} with the given root cause.
-     *
-     * @param cause the originating cause of this exception
-     */
-    public MethodNotAllowedException(Throwable cause) {
-        super(cause);
-    }
-
-    /**
-     * Creates a {@link MethodNotAllowedException} with the given detail message
-     * and root cause.
-     *
-     * @param message the detail message
-     * @param cause the originating cause of this exception
-     */
-    public MethodNotAllowedException(String message, Throwable cause) {
-        super(message, cause);
-    }
+    private static final long serialVersionUID = 1L;
 }

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/PropertyNotAllowedException.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/PropertyNotAllowedException.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import jakarta.el.ELException;
+
+/**
+ * Thrown when a property could not be accessed while evaluating a
+ * {@link jakarta.el.ValueExpression ValueExpression} or
+ * {@link jakarta.el.MethodExpression MethodExpression}.
+ *
+ * @author avpinchuk
+ */
+public class PropertyNotAllowedException extends ELException {
+
+    private static final long serialVersionUID = -1L;
+
+    /**
+     * Creates a {@link PropertyNotAllowedException} with no detail message.
+     */
+    public PropertyNotAllowedException() {
+        super();
+    }
+
+    /**
+     * Creates a {@link PropertyNotAllowedException} with the given detail message.
+     *
+     * @param message the detail message
+     */
+    public PropertyNotAllowedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a {@link PropertyNotAllowedException} with the given root cause.
+     *
+     * @param cause the originating cause of this exception
+     */
+    public PropertyNotAllowedException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a {@link PropertyNotAllowedException} with the given detail message
+     * and root cause.
+     *
+     * @param message the detail message
+     * @param cause the originating cause of this exception
+     */
+    public PropertyNotAllowedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/PropertyNotAllowedException.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/PropertyNotAllowedException.java
@@ -20,48 +20,11 @@ import jakarta.el.ELException;
 
 /**
  * Thrown when a property could not be accessed while evaluating a
- * {@link jakarta.el.ValueExpression ValueExpression} or
- * {@link jakarta.el.MethodExpression MethodExpression}.
+ * {@link jakarta.el.ValueExpression ValueExpression}.
  *
  * @author avpinchuk
  */
-public class PropertyNotAllowedException extends ELException {
+final class PropertyNotAllowedException extends ELException {
 
-    private static final long serialVersionUID = -1L;
-
-    /**
-     * Creates a {@link PropertyNotAllowedException} with no detail message.
-     */
-    public PropertyNotAllowedException() {
-        super();
-    }
-
-    /**
-     * Creates a {@link PropertyNotAllowedException} with the given detail message.
-     *
-     * @param message the detail message
-     */
-    public PropertyNotAllowedException(String message) {
-        super(message);
-    }
-
-    /**
-     * Creates a {@link PropertyNotAllowedException} with the given root cause.
-     *
-     * @param cause the originating cause of this exception
-     */
-    public PropertyNotAllowedException(Throwable cause) {
-        super(cause);
-    }
-
-    /**
-     * Creates a {@link PropertyNotAllowedException} with the given detail message
-     * and root cause.
-     *
-     * @param message the detail message
-     * @param cause the originating cause of this exception
-     */
-    public PropertyNotAllowedException(String message, Throwable cause) {
-        super(message, cause);
-    }
+    private static final long serialVersionUID = 1L;
 }

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/RestrictedELResolver.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/RestrictedELResolver.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import jakarta.el.ELClass;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+
+import java.util.Objects;
+
+/**
+ * This {@link ELResolver} exists to restrict access to the next
+ * EL expressions:
+ *
+ * <ul>
+ *     <li>Static method calls</li>
+ *     <li>Constructor calls</li>
+ *     <li>The {@code getClass() instance method calls}</li>
+ *     <li>The {@code class} instance property</li>
+ * </ul>
+ *
+ * @author avpinchuk
+ */
+public class RestrictedELResolver extends ELResolver {
+
+    @Override
+    public Object getValue(ELContext elContext, Object base, Object property) {
+        // Go to the next resolver in chain
+        if (base == null) {
+            return null;
+        }
+        // Disable 'class' instance property
+        if (Objects.equals(property, "class")) {
+            elContext.setPropertyResolved(true);
+            throw new PropertyNotAllowedException();
+        }
+        return null;
+    }
+
+    @Override
+    public Object invoke(ELContext elContext, Object base, Object method, Class<?>[] paramTypes, Object[] params) {
+        // Go to the next resolver in chain
+        if (base == null) {
+            return null;
+        }
+        // Disable static methods, constructors and 'getClass()' method
+        if (base instanceof ELClass || Objects.equals(method, "getClass")) {
+            elContext.setPropertyResolved(true);
+            throw new MethodNotAllowedException();
+        }
+        return null;
+    }
+
+    @Override
+    public Class<?> getType(ELContext elContext, Object base, Object property) {
+        return null;
+    }
+
+    @Override
+    public void setValue(ELContext elContext, Object base, Object property, Object value) {
+        // Do nothing
+    }
+
+    @Override
+    public boolean isReadOnly(ELContext elContext, Object base, Object property) {
+        return false;
+    }
+
+    @Override
+    public Class<?> getCommonPropertyType(ELContext elContext, Object base) {
+        return null;
+    }
+}

--- a/jsftemplating/src/main/java/com/sun/jsftemplating/el/RestrictedELResolver.java
+++ b/jsftemplating/src/main/java/com/sun/jsftemplating/el/RestrictedELResolver.java
@@ -31,6 +31,7 @@ import java.util.Objects;
  *     <li>Constructor calls</li>
  *     <li>The {@code getClass() instance method calls}</li>
  *     <li>The {@code class} instance property</li>
+ *     <li>Static fields</li>
  * </ul>
  *
  * @author avpinchuk
@@ -43,8 +44,8 @@ public class RestrictedELResolver extends ELResolver {
         if (base == null) {
             return null;
         }
-        // Disable 'class' instance property
-        if (Objects.equals(property, "class")) {
+        // Disable static fields and 'class' instance property
+        if (base instanceof ELClass || Objects.equals(property, "class")) {
             elContext.setPropertyResolved(true);
             throw new PropertyNotAllowedException();
         }

--- a/jsftemplating/src/main/resources/META-INF/faces-config.xml
+++ b/jsftemplating/src/main/resources/META-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,6 +31,7 @@
     <application>
         <view-handler>com.sun.jsftemplating.layout.LayoutViewHandler</view-handler>
         <state-manager>com.sun.jsftemplating.layout.LayoutStateManager</state-manager>
+        <el-resolver>com.sun.jsftemplating.el.RestrictedELResolver</el-resolver>
         <el-resolver>com.sun.jsftemplating.el.PageSessionResolver</el-resolver>
         <locale-config>
             <default-locale>en</default-locale>


### PR DESCRIPTION
Disable access in EL expressions to:

* Static method calls
* Constructor calls
* The `getClass()` method calls
* The `class` instance property
* Static fields