### PR TITLE
Removed custom getSupportedSourceVersion logic, bumped to Java 17

### DIFF
--- a/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinitionAP.java
+++ b/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinitionAP.java
@@ -98,11 +98,6 @@ public class FormatDefinitionAP extends AbstractProcessor {
   }
 
   @Override
-  public SourceVersion getSupportedSourceVersion() {
-      return SourceVersion.RELEASE_17;
-  }
-
-  @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
 
     setup();

--- a/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinitionAP.java
+++ b/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinitionAP.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,6 +25,7 @@ import java.io.StringWriter;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Set;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -42,7 +44,7 @@ import javax.tools.StandardLocation;
  * @author Romain Grecourt
  */
 @SupportedAnnotationTypes(value = {"com.sun.jsftemplating.annotation.FormatDefinition"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class FormatDefinitionAP extends AbstractProcessor {
 
   public static final String FACTORY_FILE = "META-INF/jsftemplating/FormatDefinition.map";
@@ -97,18 +99,14 @@ public class FormatDefinitionAP extends AbstractProcessor {
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
-    if (SourceVersion.latest().compareTo(SourceVersion.RELEASE_6) > 0) {
-      return SourceVersion.valueOf("RELEASE_7");
-    } else {
-      return SourceVersion.RELEASE_6;
-    }
+      return SourceVersion.RELEASE_17;
   }
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
 
     setup();
- 
+
     for (Element decl : roundEnv.getElementsAnnotatedWith(FormatDefinition.class)) {
       for (AnnotationMirror an : decl.getAnnotationMirrors()) {
         writer.println(decl.toString());

--- a/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerAP.java
+++ b/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerAP.java
@@ -270,11 +270,6 @@ public class HandlerAP extends AbstractProcessor {
   }
 
   @Override
-  public SourceVersion getSupportedSourceVersion() {
-      return SourceVersion.RELEASE_17;
-  }
-
-  @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     String key;
     Object value;

--- a/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerAP.java
+++ b/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerAP.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -55,7 +56,7 @@ import javax.tools.StandardLocation;
   "com.sun.jsftemplating.annotation.Handler",
   "com.sun.jsftemplating.annotation.HandlerInput",
   "com.sun.jsftemplating.annotation.HandlerOutput"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedOptions(value = {
     "AnnotationVerifier.Annotations",
     "AnnotationVerifier.Baseclasses",
@@ -270,11 +271,7 @@ public class HandlerAP extends AbstractProcessor {
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
-    if (SourceVersion.latest().compareTo(SourceVersion.RELEASE_6) > 0) {
-      return SourceVersion.valueOf("RELEASE_7");
-    } else {
-      return SourceVersion.RELEASE_6;
-    }
+      return SourceVersion.RELEASE_17;
   }
 
   @Override
@@ -373,18 +370,12 @@ public class HandlerAP extends AbstractProcessor {
                   pdec),
               decl);
         }
-
-// FIXME: Consider an alternate method declaration that annotates a pojo method
-//	    @Handler(id="foo")
-//	    public String method(String a, String b, String c)
-//		annotates a handler "foo" with 3 inputs (a:String, b:String, c:String) and 1 output "result:String"
-//		Will need a special way to invoke this.        
       }
     }
 
     if(_setup){
       writer.close();
-    }    
+    }
     return roundEnv.processingOver();
   }
 }

--- a/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactoryAP.java
+++ b/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactoryAP.java
@@ -119,11 +119,6 @@ public class UIComponentFactoryAP extends AbstractProcessor {
   }
 
   @Override
-  public SourceVersion getSupportedSourceVersion() {
-      return SourceVersion.RELEASE_17;
-  }
-
-  @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     setup();
     for (Element decl : roundEnv.getElementsAnnotatedWith(UIComponentFactory.class)) {

--- a/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactoryAP.java
+++ b/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactoryAP.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,6 +26,7 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -45,7 +47,7 @@ import javax.tools.StandardLocation;
  * @author Romain Grecourt
  */
 @SupportedAnnotationTypes(value = {"com.sun.jsftemplating.annotation.UIComponentFactory"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class UIComponentFactoryAP extends AbstractProcessor {
 
   public static final String FACTORY_FILE = "META-INF/jsftemplating/UIComponentFactory.map";
@@ -118,11 +120,7 @@ public class UIComponentFactoryAP extends AbstractProcessor {
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
-    if (SourceVersion.latest().compareTo(SourceVersion.RELEASE_6) > 0) {
-      return SourceVersion.valueOf("RELEASE_7");
-    } else {
-      return SourceVersion.RELEASE_6;
-    }
+      return SourceVersion.RELEASE_17;
   }
 
   @Override


### PR DESCRIPTION
Fixes #104 
First commit just kicked versions up, but then I looked into the code and I believe the logic in parent is correct:
```java
    public SourceVersion getSupportedSourceVersion() {
        SupportedSourceVersion ssv = this.getClass().getAnnotation(SupportedSourceVersion.class);
        SourceVersion sv = null;
        if (ssv == null) {
            sv = SourceVersion.RELEASE_6;
            if (isInitialized())
                processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
                                                         "No SupportedSourceVersion annotation " +
                                                         "found on " + this.getClass().getName() +
                                                         ", returning " + sv + ".");
        } else
            sv = ssv.value();
        return sv;
    }
```